### PR TITLE
docs: fix the readme header for qchem

### DIFF
--- a/workflows/qchem.ai/README.md
+++ b/workflows/qchem.ai/README.md
@@ -1,4 +1,4 @@
-# Summary.ai Example
+# Qchem.ai Example
 
 A multi-agent workflow using Maestro: Allows user to retrieve information about a chemical molecule, query quri chemistry, and get a summary of relevant news papers and patents.
 


### PR DESCRIPTION
No issue associated - vestigial name at the top to match the layout of the summary readme.