### PR TITLE
feature: package maestro serve command

### DIFF
--- a/CLI_README.md
+++ b/CLI_README.md
@@ -1,0 +1,147 @@
+# Maestro Demos CLI Tool
+
+A command-line interface for launching Maestro meta-agents-v2 workflows from any repository without needing to reference specific file paths.
+
+## Installation
+
+### From Source (Development)
+
+```bash
+# Clone the repository
+git clone https://github.com/AI4quantum/maestro-demos.git
+cd maestro-demos
+
+# Install in development mode
+pip install -e .
+```
+
+### From PyPI (Future Release)
+
+```bash
+pip install maestro-demos
+```
+
+## Prerequisites
+
+- Python 3.11 or higher
+- Maestro CLI installed: `pip install git+https://github.com/AI4quantum/maestro.git@v0.2.0`
+- Access to a Maestro backend (bee-stack, Ollama, etc.)
+
+## Usage
+
+The `maestro-demos` CLI provides two commands for launching meta-agents-v2 workflows:
+
+### 1. Create Agents (`create-agents`)
+
+Launch the agents file generation workflow API.
+
+```bash
+maestro-demos create-agents
+```
+
+This command runs:
+```bash
+maestro serve <packaged agents.yaml> <packaged workflow.yaml>
+```
+for the agents_file_generation workflow.
+
+### 2. Create Workflow (`create-workflow`)
+
+Launch the workflow file generation workflow API.
+
+```bash
+maestro-demos create-workflow
+```
+
+This command runs:
+```bash
+maestro serve <packaged agents.yaml> <packaged workflow.yaml>
+```
+for the workflow_file_generation workflow.
+
+## How It Works
+
+The CLI tool packages the meta-agents-v2 workflows from the maestro-demos repository:
+
+1. **Agents Generation**: Uses the `TaskInterpreter` and `AgentYAMLBuilder` agents to:
+   - Parse natural language goals into structured agent requirements
+   - Generate valid `agents.yaml` files with appropriate agent definitions
+
+2. **Workflow Generation**: Uses the `WorkflowBuilder` agent to:
+   - Take agent definitions and create proper `workflow.yaml` files
+   - Sequence the agents correctly and set up the workflow structure
+
+The CLI simply launches `maestro serve` with the correct packaged workflow files, so all the logic is handled by the workflow itself.
+
+## Integration with Other Repositories
+
+Once installed, you can use this CLI tool from any repository:
+
+```bash
+# In your project directory
+cd /path/to/your/project
+
+# Launch the agents generation API
+maestro-demos create-agents
+
+# Launch the workflow generation API
+maestro-demos create-workflow
+```
+
+The tool will start maestro serve with the appropriate workflow files, and you can then interact with the generated workflow through the Maestro interface.
+
+## Examples
+
+### Example 1: Launch Agents Generation API
+
+```bash
+# From any directory
+maestro-demos create-agents
+```
+
+This launches the API that can generate agents.yaml files from natural language descriptions.
+
+### Example 2: Launch Workflow Generation API
+
+```bash
+# From any directory
+maestro-demos create-workflow
+```
+
+This launches the API that can generate workflow.yaml files from agent definitions.
+
+## Troubleshooting
+
+### Maestro CLI Not Found
+
+If you get an error that maestro CLI is not found:
+
+```bash
+pip install git+https://github.com/AI4quantum/maestro.git@v0.2.0
+```
+
+### Workflow Files Not Found
+
+If you get an error about missing workflow files, ensure the package was installed correctly:
+
+```bash
+pip install -e .
+```
+
+### Backend Connection Issues
+
+Make sure you have a Maestro backend running (bee-stack, Ollama, etc.) and that your environment variables are configured correctly.
+
+## Development
+
+To contribute to the CLI tool:
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test with `pip install -e .`
+5. Submit a pull request
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details. 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.md
+include LICENSE
+include CONTRIBUTING.md
+include SECURITY.md
+include MAINTAINERS.md
+include TODO_REPORT.md
+include example.env
+recursive-include maestro_demos/workflows *.yaml 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains:
 - Agent configurations and examples
 - Complete working examples for different use cases
 - Documentation and setup guides for each demo
+- A CLI tool for launching meta-agents-v2 workflows from any repository
 
 ## Prerequisites
 
@@ -22,6 +23,11 @@ Note: If using scoring or crewai agents, install:
 ```bash
 pip install "maestro[crewai] @ git+https://github.com/AI4quantum/maestro.git@v0.2.0"
 ```
+
+**Requirements:**
+- Python 3.11 or higher
+- Maestro CLI installed
+- Access to a Maestro backend (bee-stack, Ollama, etc.)
 
 ## Getting Started
 
@@ -57,6 +63,125 @@ Browse the `workflows/` and `agents/` directories to explore various examples:
 - **Use Cases**: Real-world application examples
 
 Each demo includes its own README with specific setup and usage instructions.
+
+## CLI Tool: maestro-demos
+
+The repository includes a CLI tool that packages the meta-agents-v2 workflows so you can launch them from any repository without referencing specific file paths.
+
+### Installation
+
+#### From Source (Development)
+```bash
+# Clone the repository
+git clone https://github.com/AI4quantum/maestro-demos.git
+cd maestro-demos
+
+# Install in development mode
+pip install -e .
+```
+
+#### From PyPI (Future Release)
+```bash
+pip install maestro-demos
+```
+
+### Usage
+
+The `maestro-demos` CLI provides two commands for launching meta-agents-v2 workflows:
+
+#### 1. Create Agents (`create-agents`)
+
+Launch the agents file generation workflow API.
+
+```bash
+maestro-demos create-agents
+```
+
+This command runs:
+```bash
+maestro serve <packaged agents.yaml> <packaged workflow.yaml>
+```
+for the agents_file_generation workflow.
+
+#### 2. Create Workflow (`create-workflow`)
+
+Launch the workflow file generation workflow API.
+
+```bash
+maestro-demos create-workflow
+```
+
+This command runs:
+```bash
+maestro serve <packaged agents.yaml> <packaged workflow.yaml>
+```
+for the workflow_file_generation workflow.
+
+### How It Works
+
+The CLI tool packages the meta-agents-v2 workflows from the maestro-demos repository:
+
+1. **Agents Generation**: Uses the `TaskInterpreter` and `AgentYAMLBuilder` agents to:
+   - Parse natural language goals into structured agent requirements
+   - Generate valid `agents.yaml` files with appropriate agent definitions
+
+2. **Workflow Generation**: Uses the `WorkflowBuilder` agent to:
+   - Take agent definitions and create proper `workflow.yaml` files
+   - Sequence the agents correctly and set up the workflow structure
+
+The CLI simply launches `maestro serve` with the correct packaged workflow files, so all the logic is handled by the workflow itself.
+
+### Integration with Other Repositories
+
+Once installed, you can use this CLI tool from any repository:
+
+```bash
+# In your project directory
+cd /path/to/your/project
+
+# Launch the agents generation API
+maestro-demos create-agents
+
+# Launch the workflow generation API
+maestro-demos create-workflow
+```
+
+The tool will start maestro serve with the appropriate workflow files, and you can then interact with the generated workflow through the Maestro interface.
+
+### Examples
+
+#### Example 1: Launch Agents Generation API
+```bash
+# From any directory
+maestro-demos create-agents
+```
+
+This launches the API that can generate agents.yaml files from natural language descriptions.
+
+#### Example 2: Launch Workflow Generation API
+```bash
+# From any directory
+maestro-demos create-workflow
+```
+
+This launches the API that can generate workflow.yaml files from agent definitions.
+
+### Troubleshooting
+
+#### Maestro CLI Not Found
+If you get an error that maestro CLI is not found:
+```bash
+pip install git+https://github.com/AI4quantum/maestro.git@v0.2.0
+```
+
+#### Workflow Files Not Found
+If you get an error about missing workflow files, ensure the package was installed correctly:
+```bash
+pip install -e .
+```
+
+#### Backend Connection Issues
+Make sure you have a Maestro backend running (bee-stack, Ollama, etc.) and that your environment variables are configured correctly.
 
 ## Environment Setup
 

--- a/maestro_demos/__init__.py
+++ b/maestro_demos/__init__.py
@@ -1,0 +1,10 @@
+"""
+Maestro Demos CLI Tool
+
+A command-line interface for running Maestro meta-agents workflows
+from any repository without needing to reference specific file paths.
+"""
+
+__version__ = "0.1.0"
+__author__ = "George Liu"
+__email__ = "george.liu@ibm.com" 

--- a/maestro_demos/cli.py
+++ b/maestro_demos/cli.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Maestro Demos CLI Tool
+
+Provides commands to run meta-agents-v2 workflows for generating
+agents.yaml and workflow.yaml files from any directory, by launching
+maestro serve with the correct packaged workflow files.
+"""
+
+import sys
+import subprocess
+from pathlib import Path
+
+import click
+
+
+def get_package_root() -> Path:
+    """Get the root directory of the maestro_demos package."""
+    import maestro_demos
+    return Path(maestro_demos.__file__).parent
+
+
+def get_workflow_paths() -> tuple[Path, Path]:
+    """Get the paths to the meta-agents-v2 workflow files."""
+    package_root = get_package_root()
+    
+    agents_generation_dir = package_root / "workflows" / "meta-agents-v2" / "agents_file_generation"
+    workflow_generation_dir = package_root / "workflows" / "meta-agents-v2" / "workflow_file_generation"
+    
+    return agents_generation_dir, workflow_generation_dir
+
+
+def check_maestro_installed() -> bool:
+    """Check if maestro CLI is available."""
+    try:
+        subprocess.run(["maestro", "--help"], capture_output=True, check=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def run_maestro_serve(agents_yaml: Path, workflow_yaml: Path) -> None:
+    """Run maestro serve with the specified workflow files."""
+    if not check_maestro_installed():
+        click.echo("❌ Error: maestro CLI is not installed or not in PATH", err=True)
+        click.echo("Please install maestro first: pip install git+https://github.com/AI4quantum/maestro.git@v0.2.0", err=True)
+        sys.exit(1)
+    
+    click.echo(f"🚀 Starting maestro serve with:")
+    click.echo(f"   Agents: {agents_yaml}")
+    click.echo(f"   Workflow: {workflow_yaml}")
+    click.echo()
+    
+    try:
+        subprocess.run([
+            "maestro", "serve",
+            str(agents_yaml),
+            str(workflow_yaml)
+        ], check=True)
+    except subprocess.CalledProcessError as e:
+        click.echo(f"❌ Error running maestro serve: {e}", err=True)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        click.echo("\n👋 Stopped by user")
+        sys.exit(0)
+
+
+@click.group()
+@click.version_option(version="0.1.0", prog_name="maestro-demos")
+def main():
+    """
+    Maestro Demos CLI Tool
+    
+    Run meta-agents-v2 workflows for generating agents.yaml and workflow.yaml files
+    from any directory. This tool simply launches maestro serve with the correct
+    packaged workflow files, so you do not need to reference any paths manually.
+    """
+    pass
+
+
+@main.command()
+def create_agents():
+    """
+    Launch the meta-agents-v2 agents file generation workflow API.
+    
+    This command runs:
+        maestro serve <packaged agents.yaml> <packaged workflow.yaml>
+    for the agents_file_generation workflow.
+    """
+    agents_dir, _ = get_workflow_paths()
+    agents_yaml = agents_dir / "agents.yaml"
+    workflow_yaml = agents_dir / "workflow.yaml"
+    
+    if not agents_yaml.exists() or not workflow_yaml.exists():
+        click.echo("❌ Error: Required workflow files not found in the package.", err=True)
+        sys.exit(1)
+    
+    run_maestro_serve(agents_yaml.resolve(), workflow_yaml.resolve())
+
+
+@main.command()
+def create_workflow():
+    """
+    Launch the meta-agents-v2 workflow file generation workflow API.
+    
+    This command runs:
+        maestro serve <packaged agents.yaml> <packaged workflow.yaml>
+    for the workflow_file_generation workflow.
+    """
+    _, workflow_dir = get_workflow_paths()
+    agents_yaml = workflow_dir / "agents.yaml"
+    workflow_yaml = workflow_dir / "workflow.yaml"
+    
+    if not agents_yaml.exists() or not workflow_yaml.exists():
+        click.echo("❌ Error: Required workflow files not found in the package.", err=True)
+        sys.exit(1)
+    
+    run_maestro_serve(agents_yaml.resolve(), workflow_yaml.resolve())
+
+
+if __name__ == '__main__':
+    main() 

--- a/maestro_demos/workflows/meta-agents-v2/agents_file_generation/agents.yaml
+++ b/maestro_demos/workflows/meta-agents-v2/agents_file_generation/agents.yaml
@@ -1,0 +1,153 @@
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: TaskInterpreter
+  labels:
+    app: meta-agents-v2
+spec:
+  model: deepseek-r1:latest
+  framework: beeai
+  mode: remote
+  description: "Parses user goals and converts them into a structured list of agents with descriptions."
+  instructions: |
+    You are a **task-to-agent planner** that takes a user's natural language input and outputs a list of agents needed to accomplish that task.
+
+    ## Your task:
+    Convert the user’s goal into a **structured YAML block** that includes:
+    - The number of agents
+    - Agent names (short and descriptive)
+    - One-line description for each agent’s function
+
+    ## Output Format:
+    ```
+    number of agents: <X>
+    agent1: <name> – <description>
+    agent2: <name> – <description>
+    ...
+    ```
+
+    ## Guidelines:
+    - Use **concise, meaningful names** for each agent (e.g., `weather_retriever`, `trend_analyzer`).
+    - Descriptions should be **one sentence** starting with a verb, clearly stating the function.
+    - Prefer 1–3 agents unless task truly requires more.
+    - Try to combine related logic into a single agent when it simplifies the workflow without losing clarity.
+    - **Avoid duplicating tasks** across agents.
+    - If the user’s request is vague, make **reasonable assumptions** and err on the side of simplicity.
+
+    ## Examples:
+
+    ### Example 1:
+    Input: "I want to compare the current weather with the historical averages."
+    Output:
+    ```
+    number of agents: 2
+    agent1: weather_retriever – Retrieves today’s weather for a location.
+    agent2: trend_analyzer – Compares today’s weather to the 7-day historical average.
+    ```
+
+    ### Example 2:
+    Input: "Get the latest news headlines and summarize them."
+    Output:
+    ```
+    number of agents: 2
+    agent1: news_fetcher – Retrieves current news headlines from a news API.
+    agent2: summarizer – Condenses headlines into a short summary paragraph.
+    ```
+
+    ### Example 3:
+    Input: "Analyze sentiment of Reddit posts about Nvidia."
+    Output:
+    ```
+    number of agents: 2
+    agent1: reddit_scraper – Fetches Reddit posts about Nvidia.
+    agent2: sentiment_analyzer – Determines sentiment of the collected posts.
+    ```
+
+---
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: AgentYAMLBuilder
+  labels:
+    app: meta-agents-v2
+spec:
+  model: deepseek-r1:latest
+  framework: beeai
+  mode: remote
+  description: "Generates valid agents.yaml files using either LLM or code agents depending on the task."
+  instructions: |
+    You are an Agent YAML Generator. Given a list of agent names and descriptions, output a *single YAML file* with all agents, separated by `---`.
+    Note: these agents will be chained, which means the output of the agent n will be the input of the agent n-1. Keep this in mind when writing the instructions for the agent.
+
+    Decide agent type:
+    - Use a code agent for API calls, parsing, I/O, or simple math.
+    - Use an LLM agent for summarization, comparison, or generation tasks.
+
+    Format — Code Agent:
+    apiVersion: maestro/v1alpha1
+    kind: Agent
+    metadata:
+      name: <agent_name>
+      labels:
+        app: <generate>
+    spec:
+      framework: code
+      mode: local
+      description: |
+        <what this agent does>
+      code: |
+        <valid Python code with all necessary imports, no def blocks, no function declarations, no return statements. Code must run top-down, assigning results to variables and output>
+
+    Format — LLM Agent:
+    apiVersion: maestro/v1alpha1
+    kind: Agent
+    metadata:
+      name: <agent_name>
+      labels:
+        app: <generate>
+    spec:
+      model: deepseek-r1:latest
+      framework: beeai
+      mode: remote
+      description: |
+        <short summary of purpose>
+      instructions: |
+        <detailed prompt for behavior>
+
+    Rules:
+    - Use `|` for all multiline fields
+    - No functions, global state, or inter-agent assumptions
+    - All code must be self-contained and include imports
+    - metadata.name must match input exactly
+    - Output one valid YAML file, agents separated by `---`
+
+    Example Output Format:
+    apiVersion: maestro/v1alpha1
+    kind: Agent
+    metadata:
+      name: github_file_fetcher
+      labels:
+        app: generated
+    spec:
+      framework: code
+      mode: local
+      description: |
+        Fetches contents of a file from a GitHub URL.
+      code: |
+        <generated code, with no functions>
+
+    ---
+    apiVersion: maestro/v1alpha1
+    kind: Agent
+    metadata:
+      name: file_summarizer
+      labels:
+        app: generated
+    spec:
+      model: deepseek-r1:latest
+      framework: beeai
+      mode: remote
+      description: |
+        Summarizes the given file’s contents.
+      instructions: |
+        <generate applicable instructions>

--- a/maestro_demos/workflows/meta-agents-v2/agents_file_generation/workflow.yaml
+++ b/maestro_demos/workflows/meta-agents-v2/agents_file_generation/workflow.yaml
@@ -1,0 +1,20 @@
+apiVersion: maestro/v1alpha1
+kind: Workflow
+metadata:
+  name: meta-agents-v2
+  labels:
+    app: meta-agents-v2
+spec:
+  template:
+    metadata:
+      labels:
+        app: meta-agents-v2
+    agents:
+      - TaskInterpreter
+      - AgentYAMLBuilder
+    prompt: I want to fetch the current stock prices for Apple and Microsoft, and then analyze which one has performed better over the past week.
+    steps:
+    - name: step1
+      agent: TaskInterpreter
+    - name: step2
+      agent: AgentYAMLBuilder

--- a/maestro_demos/workflows/meta-agents-v2/workflow_file_generation/agents.yaml
+++ b/maestro_demos/workflows/meta-agents-v2/workflow_file_generation/agents.yaml
@@ -1,0 +1,79 @@
+apiVersion: maestro/v1alpha1
+kind: Agent
+metadata:
+  name: WorkflowBuilder
+  labels:
+    app: meta-agents-v2
+spec:
+  model: deepseek-r1:latest
+  framework: beeai
+  mode: remote
+  description: |
+    Generates a valid workflow.yaml by sequencing agents defined in agents.yaml.
+    It infers execution order from the list and places the input prompt at the top.
+  instructions: |
+    You are a Workflow YAML Generator. Given an ordered list of agent names (from agents.yaml), generate a valid workflow.yaml file for a Maestro workflow.
+    Note: you may receive a description of the agents in addition to just its names. The descriptions are not needed, only plug in the agent name into the relevant step.
+    Format the output like this:
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: <workflow_name>
+      labels:
+        app: <generate>
+    spec:
+      template:
+        metadata:
+          labels:
+            app: <generate>
+        agents:
+          - <agent_name_1>
+          - <agent_name_2>
+          - <agent_name_n>
+        prompt: <initial_user_prompt>: Copy the initial user prompt passed in here
+        steps:
+          - name: <step_name_1>
+            agent: <agent_name_1>
+          - name: <step_name_2>
+            agent: <agent_name_2>
+          - name: <step_name_n>
+            agent: <agent_name_n>
+
+    Guidelines:
+    - The order of agents in both `agents` and `steps` must follow the input list.
+    - Use the same name for each step as its corresponding agent.
+    - `prompt` is the original user goal which is to be passed as input into the first agent
+    - Do not include `entrypoint`, `next`, or `with`.
+    - Generate appropriate names for the <generate> app labels
+
+    Example Input:
+    agents:
+      - github_file_fetcher: gets file from github
+      - file_summarizer: summarizes file from github
+      - summary_evaluator: evaluates if the summary is good
+    prompt: Summarize the contents of this GitHub file.
+
+    Example Output:
+    apiVersion: maestro/v1alpha1
+    kind: Workflow
+    metadata:
+      name: summarize-github-file
+      labels:
+        app: <generate>
+    spec:
+      template:
+        metadata:
+          labels:
+            app: <generate>
+        agents:
+          - github_file_fetcher
+          - file_summarizer
+          - summary_evaluator
+        prompt: Summarize the contents of this GitHub file.
+        steps:
+          - name: step1
+            agent: github_file_fetcher
+          - name: step2
+            agent: file_summarizer
+          - name: step3
+            agent: summary_evaluator

--- a/maestro_demos/workflows/meta-agents-v2/workflow_file_generation/workflow.yaml
+++ b/maestro_demos/workflows/meta-agents-v2/workflow_file_generation/workflow.yaml
@@ -1,0 +1,21 @@
+apiVersion: maestro/v1alpha1
+kind: Workflow
+metadata:
+  name: meta-agents-v2
+  labels:
+    app: meta-agents-v2
+spec:
+  template:
+    metadata:
+      labels:
+        app: meta-agents-v2
+    agents:
+      - WorkflowBuilder
+    prompt: |
+      stock_data_retriever – Retrieves current stock prices for Apple (AAPL) and Microsoft (MSFT).
+      financial_historical_data_retriever – Retrieves historical stock data for the past week for both companies.
+      stock_performance_analyzer – Analyzes which stock has performed better over the past week based on historical data.
+      prompt:  I want to fetch the current stock prices for Apple and Microsoft, and then analyze which one has performed better over the past week. 
+    steps:
+      - name: step1
+        agent: WorkflowBuilder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maestro-demos"
+version = "0.1.0"
+description = "CLI tool for running Maestro meta-agents workflows"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "George Liu", email = "george.liu@ibm.com"}
+]
+maintainers = [
+    {name = "George Liu", email = "george.liu@ibm.com"}
+]
+keywords = ["maestro", "ai", "agents", "workflows", "cli"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+requires-python = ">=3.11"
+dependencies = [
+    "maestro>=0.2.0",
+    "click>=8.0.0",
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+maestro-demos = "maestro_demos.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/AI4quantum/maestro-demos"
+Repository = "https://github.com/AI4quantum/maestro-demos"
+Issues = "https://github.com/AI4quantum/maestro-demos/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.setuptools.package-data]
+maestro_demos = [
+    "workflows/meta-agents-v2/agents_file_generation/*.yaml",
+    "workflows/meta-agents-v2/workflow_file_generation/*.yaml",
+] 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,43 @@
+from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name="maestro-demos",
+    version="0.1.0",
+    author="Maestro Demos Team",
+    author_email="team@maestro-demos.com",
+    description="CLI tool for running Maestro meta-agents workflows",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/AI4quantum/maestro-demos",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+    ],
+    python_requires=">=3.11",
+    install_requires=[
+        "maestro>=0.2.0",
+        "click>=8.0.0",
+        "pyyaml>=6.0",
+    ],
+    entry_points={
+        "console_scripts": [
+            "maestro-demos=maestro_demos.cli:main",
+        ],
+    },
+    include_package_data=True,
+    package_data={
+        "maestro_demos": [
+            "workflows/meta-agents-v2/agents_file_generation/*.yaml",
+            "workflows/meta-agents-v2/workflow_file_generation/*.yaml",
+        ],
+    },
+) 

--- a/test_cli.py
+++ b/test_cli.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Simple test script to verify the maestro-demos CLI functionality.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_help():
+    """Test that the CLI help command works."""
+    try:
+        result = subprocess.run(
+            ["maestro-demos", "--help"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print("✅ CLI help command works")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"❌ CLI help command failed: {e}")
+        print(f"stdout: {e.stdout}")
+        print(f"stderr: {e.stderr}")
+        return False
+
+
+def test_create_agents_help():
+    """Test that the create-agents help command works."""
+    try:
+        result = subprocess.run(
+            ["maestro-demos", "create-agents", "--help"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print("✅ create-agents help command works")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"❌ create-agents help command failed: {e}")
+        print(f"stdout: {e.stdout}")
+        print(f"stderr: {e.stderr}")
+        return False
+
+
+def test_create_workflow_help():
+    """Test that the create-workflow help command works."""
+    try:
+        result = subprocess.run(
+            ["maestro-demos", "create-workflow", "--help"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print("✅ create-workflow help command works")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"❌ create-workflow help command failed: {e}")
+        print(f"stdout: {e.stdout}")
+        print(f"stderr: {e.stderr}")
+        return False
+
+
+def test_workflow_files_exist():
+    """Test that the workflow files are properly included in the package."""
+    try:
+        from maestro_demos.cli import get_workflow_paths
+        agents_dir, workflow_dir = get_workflow_paths()
+        
+        agents_yaml = agents_dir / "agents.yaml"
+        agents_workflow_yaml = agents_dir / "workflow.yaml"
+        workflow_agents_yaml = workflow_dir / "agents.yaml"
+        workflow_yaml = workflow_dir / "workflow.yaml"
+        
+        files_exist = all([
+            agents_yaml.exists(),
+            agents_workflow_yaml.exists(),
+            workflow_agents_yaml.exists(),
+            workflow_yaml.exists()
+        ])
+        
+        if files_exist:
+            print("✅ All workflow files found in package")
+            return True
+        else:
+            print("❌ Some workflow files missing:")
+            print(f"   agents.yaml: {agents_yaml.exists()}")
+            print(f"   agents workflow.yaml: {agents_workflow_yaml.exists()}")
+            print(f"   workflow agents.yaml: {workflow_agents_yaml.exists()}")
+            print(f"   workflow.yaml: {workflow_yaml.exists()}")
+            return False
+            
+    except Exception as e:
+        print(f"❌ Error checking workflow files: {e}")
+        return False
+
+
+def test_absolute_paths():
+    """Test that the CLI can resolve absolute paths to workflow files."""
+    try:
+        from maestro_demos.cli import get_workflow_paths
+        agents_dir, workflow_dir = get_workflow_paths()
+        
+        agents_yaml = agents_dir / "agents.yaml"
+        agents_workflow_yaml = agents_dir / "workflow.yaml"
+        workflow_agents_yaml = workflow_dir / "agents.yaml"
+        workflow_yaml = workflow_dir / "workflow.yaml"
+        
+        # Test that resolve() works and returns absolute paths
+        absolute_paths = [
+            agents_yaml.resolve(),
+            agents_workflow_yaml.resolve(),
+            workflow_agents_yaml.resolve(),
+            workflow_yaml.resolve()
+        ]
+        
+        all_absolute = all(path.is_absolute() for path in absolute_paths)
+        
+        if all_absolute:
+            print("✅ All workflow files resolve to absolute paths")
+            return True
+        else:
+            print("❌ Some workflow files do not resolve to absolute paths")
+            return False
+            
+    except Exception as e:
+        print(f"❌ Error testing absolute paths: {e}")
+        return False
+
+
+def main():
+    """Run all tests."""
+    print("🧪 Testing maestro-demos CLI...")
+    print()
+    
+    tests = [
+        test_cli_help,
+        test_create_agents_help,
+        test_create_workflow_help,
+        test_workflow_files_exist,
+        test_absolute_paths,
+    ]
+    
+    passed = 0
+    total = len(tests)
+    
+    for test in tests:
+        if test():
+            passed += 1
+        print()
+    
+    print(f"📊 Test Results: {passed}/{total} tests passed")
+    
+    if passed == total:
+        print("🎉 All tests passed! The CLI tool is working correctly.")
+        return 0
+    else:
+        print("❌ Some tests failed. Please check the output above.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main()) 


### PR DESCRIPTION
Previously, users could only run meta-agents-v2 workflows from within the maestro-demos repository because the workflow files were hardcoded to specific paths. This required having both the maestro-demos repo and the target repo open simultaneously. This PR adds a Python CLI package called maestro-demos that packages the meta-agents-v2 workflows so they can be launched from any repository without referencing specific file paths. The CLI provides a simple launcher interface for the existing meta-agents-v2 functionality.

## commands
```
maestro-demos create-agents
```
Purpose: Launch the meta-agents-v2 agents file generation workflow API
Equivalent to: maestro serve ./meta-agents-v2/agents_file_generation/agents.yaml ./meta-agents-v2/agents_file_generation/workflow.yaml
```
maestro-demos create-workflow
```
Purpose: Launch the meta-agents-v2 workflow file generation workflow API
Equivalent to: maestro serve ./meta-agents-v2/workflow_file_generation/agents.yaml ./meta-agents-v2/workflow_file_generation/workflow.yaml

## Installation
``` pip install git+https://github.com/AI4quantum/maestro-demos.git```


Goal is to allow this to be callled inside of maestro builder's ./start.sh; this allows both apis to start at the same time w/o having to do extra work